### PR TITLE
test(harness): normalize status path assertions

### DIFF
--- a/crates/mimir-harness/tests/binary.rs
+++ b/crates/mimir-harness/tests/binary.rs
@@ -183,6 +183,18 @@ fn status_value<'a>(stdout: &'a str, key: &str) -> Option<&'a str> {
     stdout.lines().find_map(|line| line.strip_prefix(&prefix))
 }
 
+fn normalize_status_path_text(value: &str) -> String {
+    let normalized = value.replace('\\', "/");
+    if let Some(stripped) = normalized.strip_prefix("/private/var/") {
+        return format!("/var/{stripped}");
+    }
+    normalized
+}
+
+fn expected_status_path(path: &Path) -> String {
+    normalize_status_path_text(&path.display().to_string())
+}
+
 fn remote_status_stdout(project: &Path) -> Result<String, Box<dyn std::error::Error>> {
     remote_status_stdout_with_args(project, &[])
 }
@@ -459,12 +471,17 @@ fn status_project_root_does_not_fallback_to_wrapped_env_config(
         explicit_config_stdout.contains("config_status=ready"),
         "status should use the explicit config path:\n{explicit_config_stdout}"
     );
-    assert!(
-        explicit_config_stdout.contains(&format!("drafts_dir={}", wrapped_drafts.display())),
+    let actual_drafts_dir = status_value(&explicit_config_stdout, "drafts_dir")
+        .map(normalize_status_path_text)
+        .ok_or("status output should include drafts_dir")?;
+    assert_eq!(
+        actual_drafts_dir,
+        expected_status_path(&wrapped_drafts),
         "status should use the explicit config's drafts root:\n{explicit_config_stdout}"
     );
-    assert!(
-        !explicit_config_stdout.contains(&foreign_drafts.display().to_string()),
+    assert_ne!(
+        actual_drafts_dir,
+        expected_status_path(&foreign_drafts),
         "explicit config should not inherit wrapped drafts dir:\n{explicit_config_stdout}"
     );
     Ok(())

--- a/crates/mimir-harness/tests/bootstrap.rs
+++ b/crates/mimir-harness/tests/bootstrap.rs
@@ -2344,7 +2344,7 @@ fn render_operator_status_falls_back_to_env_when_cwd_has_no_config(
     let actual_config_path = status_value(&output, "config_path")
         .map(normalize_status_path_text)
         .ok_or("status output should include config_path")?;
-    let env_path = normalized_expected_status_path(&env_config);
+    let env_path = normalize_status_path_text(&env_config.display().to_string());
 
     assert_eq!(
         actual_config_path, env_path,

--- a/crates/mimir-harness/tests/bootstrap.rs
+++ b/crates/mimir-harness/tests/bootstrap.rs
@@ -48,6 +48,23 @@ fn normalize_test_path(path: &Path) -> PathBuf {
     normalize_test_path(parent).join(file_name)
 }
 
+fn status_value<'a>(output: &'a str, key: &str) -> Option<&'a str> {
+    let prefix = format!("{key}=");
+    output.lines().find_map(|line| line.strip_prefix(&prefix))
+}
+
+fn normalize_status_path_text(value: &str) -> String {
+    let normalized = value.replace('\\', "/");
+    if let Some(stripped) = normalized.strip_prefix("/private/var/") {
+        return format!("/var/{stripped}");
+    }
+    normalized
+}
+
+fn normalized_expected_status_path(path: &Path) -> String {
+    normalize_status_path_text(&normalize_test_path(path).display().to_string())
+}
+
 fn test_file_uri(path: &Path) -> String {
     format!("file://{}", normalize_test_path(path).display())
 }
@@ -2288,16 +2305,19 @@ fn render_operator_status_prefers_cwd_config_over_env_path(
     );
 
     let output = render_operator_status(&cwd_project, &env_map)?;
-    let cwd_line = format!("config_path={}", normalize_test_path(&cwd_config).display());
-    let env_line = format!("config_path={}", normalize_test_path(&env_config).display());
+    let actual_config_path = status_value(&output, "config_path")
+        .map(normalize_status_path_text)
+        .ok_or("status output should include config_path")?;
+    let cwd_path = normalized_expected_status_path(&cwd_config);
+    let env_path = normalized_expected_status_path(&env_config);
 
-    assert!(
-        output.contains(&cwd_line),
-        "expected cwd config_path in status output:\nlooking for: {cwd_line}\ngot:\n{output}"
+    assert_eq!(
+        actual_config_path, cwd_path,
+        "expected cwd config_path in status output:\ngot:\n{output}"
     );
-    assert!(
-        !output.contains(&env_line),
-        "env config_path should not appear when cwd has its own:\nlooking against: {env_line}\ngot:\n{output}"
+    assert_ne!(
+        actual_config_path, env_path,
+        "env config_path should not appear when cwd has its own:\ngot:\n{output}"
     );
     Ok(())
 }
@@ -2321,11 +2341,14 @@ fn render_operator_status_falls_back_to_env_when_cwd_has_no_config(
     );
 
     let output = render_operator_status(&cwd_no_config, &env_map)?;
-    let env_line = format!("config_path={}", normalize_test_path(&env_config).display());
+    let actual_config_path = status_value(&output, "config_path")
+        .map(normalize_status_path_text)
+        .ok_or("status output should include config_path")?;
+    let env_path = normalized_expected_status_path(&env_config);
 
-    assert!(
-        output.contains(&env_line),
-        "expected env-fallback config_path:\nlooking for: {env_line}\ngot:\n{output}"
+    assert_eq!(
+        actual_config_path, env_path,
+        "expected env-fallback config_path:\ngot:\n{output}"
     );
     Ok(())
 }
@@ -2354,16 +2377,19 @@ fn render_operator_status_prefers_cwd_drafts_dir_over_env_drafts_dir(
     );
 
     let output = render_operator_status(&cwd_project, &env_map)?;
-    let cwd_line = format!("drafts_dir={}", normalize_test_path(&cwd_drafts).display());
-    let env_line = format!("drafts_dir={}", normalize_test_path(&env_drafts).display());
+    let actual_drafts_dir = status_value(&output, "drafts_dir")
+        .map(normalize_status_path_text)
+        .ok_or("status output should include drafts_dir")?;
+    let cwd_drafts_path = normalized_expected_status_path(&cwd_drafts);
+    let env_drafts_path = normalized_expected_status_path(&env_drafts);
 
-    assert!(
-        output.contains(&cwd_line),
-        "expected cwd drafts_dir in status output:\nlooking for: {cwd_line}\ngot:\n{output}"
+    assert_eq!(
+        actual_drafts_dir, cwd_drafts_path,
+        "expected cwd drafts_dir in status output:\ngot:\n{output}"
     );
-    assert!(
-        !output.contains(&env_line),
-        "env drafts_dir should not appear when cwd config has storage:\nlooking against: {env_line}\ngot:\n{output}"
+    assert_ne!(
+        actual_drafts_dir, env_drafts_path,
+        "env drafts_dir should not appear when cwd config has storage:\ngot:\n{output}"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Normalize status path assertion text in harness tests across macOS /private/var aliases and Windows separators
- Compare parsed status key values instead of brittle full-output substrings

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings