### PR TITLE
ci: update macos release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
             archive: tar.gz
             cross: true
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
             archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
## Summary
- move the Intel macOS release artifact job from retired macos-13 to supported macos-15-intel

## Verification
- cargo build --workspace
- cargo test --workspace
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings