### PR TITLE
Align Mimir public release docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ labels: bug
 
 ## What was expected
 
-<!-- The designed or documented behavior. Cite the spec or AGENTS.md invariant. -->
+<!-- The designed or documented behavior. Cite the relevant spec or invariant. -->
 
 ## Minimum reproduction
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,4 +18,4 @@ labels: feature
 
 ## Architectural fit
 
-<!-- Cross-reference AGENTS.md invariants. Does this require a new invariant or spec under `docs/concepts/`? -->
+<!-- Cross-reference documented invariants. Does this require a new invariant or spec under `docs/concepts/`? -->

--- a/.github/ISSUE_TEMPLATE/spec_question.md
+++ b/.github/ISSUE_TEMPLATE/spec_question.md
@@ -6,7 +6,7 @@ labels: spec-question
 
 ## Area
 
-<!-- Which spec file under `docs/concepts/` or which `AGENTS.md` invariant. -->
+<!-- Which spec file under `docs/concepts/` or which documented invariant. -->
 
 ## Question
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-Keep this PR scoped and atomic. See CONTRIBUTING.md and AGENTS.md for conventions.
+Keep this PR scoped and atomic. See CONTRIBUTING.md for public conventions.
 No AI attribution anywhere in the PR body or commit messages.
 -->
 
@@ -25,15 +25,15 @@ Choose the closest current track:
 <!--
 Evidence the change is correct. Test output, spec cross-references, reproduction commands.
 Tests passing is not correctness. Attach fresh verification output for any "done" claim.
-If GitHub Actions is disabled for quota, include the local gate output required by AGENTS.md.
+If GitHub Actions is disabled for quota, include the relevant local gate output.
 -->
 
 ## Checklist
 
 - [ ] Conventional Commits format on every commit
 - [ ] No AI attribution in commits, PR body, or any file
-- [ ] Primary sources cited, or marked `pending verification` per AGENTS.md
-- [ ] Relevant `AGENTS.md` invariants reviewed for conflict
+- [ ] Primary sources cited, or marked `pending verification`
+- [ ] Relevant public docs and architectural invariants reviewed for conflict
 - [ ] Public-facing status claims stay bounded to implemented and verified behavior
 - [ ] Local gate output included if CI is unavailable due quota
 - [ ] `STATUS.md` updated if milestone or phase state changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to Mimir are documented in this file.
 
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Mimir adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reaches a first release; version policy is documented in `PRINCIPLES.md`.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Mimir follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for published releases; version policy is documented in `PRINCIPLES.md`.
 
 ## [Unreleased]
 
 ### Added — launch publication assets
 
-- **Launch article and posting assets** — added the public launch article, linked it from the docs index and README, and aligned the posting plan with the approved launch channels: GitHub, launch article, Show HN / X / LinkedIn, Codex plugin bundle, and crates.io/docs.rs alpha with MCP registry submission deferred.
+- **Launch article** — added the public launch article and linked it from the docs index and README.
 - **Hidden planning archive** — moved historical planning notes into `.planning/planning` and removed stale public-doc links to planning scratch.
 
 ### Changed — public launch surface

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ mimir remote push
 - [`PRINCIPLES.md`](PRINCIPLES.md) - engineering principles and architectural boundaries.
 - [`docs/concepts/`](docs/concepts/) - architecture specs.
 - [`docs/launch-readiness.md`](docs/launch-readiness.md) - OSS, engineering, and promise sign-off checklist.
-- [`docs/launch-posting-plan.md`](docs/launch-posting-plan.md) - launch article, listing, and posting plan.
+- [`RELEASING.md`](RELEASING.md) - release process and package workflow.
 - [`docs/blog/2026-04-28-agent-memory-compiler-pipeline.md`](docs/blog/2026-04-28-agent-memory-compiler-pipeline.md) - launch article.
 
 ## Contributing

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 This document is the canonical runbook for cutting a release. The pipeline lives in `.github/workflows/release.yml`.
 
-Mimir follows [SemVer](https://semver.org/) once it reaches its first release. Pre-1.0 series may carry breaking wire-format changes between minor versions and will be called out in `CHANGELOG.md` under `### Changed — wire format`.
+Mimir follows [SemVer](https://semver.org/) for published releases. Pre-1.0 series may carry breaking wire-format changes between minor versions and will be called out in `CHANGELOG.md` under `### Changed — wire format`.
 
 ## Versioning policy
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,10 +1,10 @@
 ---
 project: Mimir
-phase: pre-1.0 public launch cleanup
-last_updated: 2026-04-28
+phase: post-v0.1.0 alpha cleanup
+last_updated: 2026-04-30
 version: 0.1.0
-release_tags: none
-ci_state: "main green on 2026-04-28 after PR #11; cleanup branch local gate passed on 2026-04-28"
+release_tags: v0.1.0
+ci_state: "main green on 2026-04-28 after PR #11; current branch verification is recorded in PR evidence"
 blockers: []
 ---
 
@@ -24,7 +24,7 @@ Mimir is an experimental local-first memory governance system for AI agents. It 
 | MCP | `mimir-mcp` exposes local governed memory tools over stdio MCP. |
 | Recovery | Git-backed remote push/pull/drill flows verify append-only log integrity and copy draft JSON without mutating canonical history. |
 | Benchmarks | Recovery benchmark fixtures and validation harness live under `benchmarks/recovery`; live benchmark claims are not made yet. |
-| Release | Workspace version is `0.1.0`; no release tag exists yet. Tag `v0.1.0` only after the owner approves the release step. |
+| Release | Workspace version is `0.1.0`; tag `v0.1.0` points to commit `315d791`, and GitHub Release `v0.1.0` was published on 2026-04-28 with platform archives and checksums. |
 
 ## Architectural Boundaries
 
@@ -37,12 +37,12 @@ Mimir is an experimental local-first memory governance system for AI agents. It 
 
 ## Launch Work Order
 
-1. Public surface scrub: remove tracked scratch artifacts and stale public references.
-2. README and docs index cleanup.
-3. OSS readiness, engineering quality, and promise-audit checklist.
-4. Marketing, article, posting, and listing plan.
-5. Local verification only: build, tests, fmt, clippy, targeted benchmark checks, docs/package checks where relevant.
-6. One batched commit and one push after local green.
+1. Keep public documentation links aligned with files that exist in the repo.
+2. Keep README and docs index cleanup batched with other public admin updates.
+3. Keep OSS readiness, engineering quality, and promise-audit status current.
+4. Keep future release communication and listing work separate from implementation status.
+5. Verify locally before pushing: build, tests, fmt, clippy, targeted benchmark checks, docs/package checks where relevant.
+6. Use one batched commit and one push after local green.
 
 ## Public Claims Allowed Now
 
@@ -64,6 +64,6 @@ Mimir is an experimental local-first memory governance system for AI agents. It 
 - [`README.md`](README.md) - public entry point.
 - [`docs/README.md`](docs/README.md) - documentation index.
 - [`docs/launch-readiness.md`](docs/launch-readiness.md) - current launch checklist.
-- [`docs/launch-posting-plan.md`](docs/launch-posting-plan.md) - launch posting and listing plan.
+- [`RELEASING.md`](RELEASING.md) - release runbook.
 - [`docs/concepts/`](docs/concepts/) - architecture specs.
 - [`PRINCIPLES.md`](PRINCIPLES.md) - engineering principles and architectural boundaries.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,6 @@ This is the public documentation index for Mimir. Planning notes remain availabl
 - [`first-run.md`](first-run.md) - fresh-clone walkthrough.
 - [`bc-dr-restore.md`](bc-dr-restore.md) - Git-backed backup and restore flow.
 - [`launch-readiness.md`](launch-readiness.md) - OSS readiness, engineering quality, and promise audit.
-- [`launch-posting-plan.md`](launch-posting-plan.md) - launch article, posting, and listing plan.
 - [`blog/2026-04-28-agent-memory-compiler-pipeline.md`](blog/2026-04-28-agent-memory-compiler-pipeline.md) - public launch article.
 
 ## Architecture
@@ -31,4 +30,4 @@ This is the public documentation index for Mimir. Planning notes remain availabl
 
 ## Launch Execution
 
-Historical planning notes are kept outside the public docs tree. Current launch execution is tracked in [`launch-readiness.md`](launch-readiness.md) and [`launch-posting-plan.md`](launch-posting-plan.md).
+Historical planning notes are kept outside the public docs tree. Current release state is tracked in [`../STATUS.md`](../STATUS.md), readiness evidence in [`launch-readiness.md`](launch-readiness.md), and release mechanics in [`../RELEASING.md`](../RELEASING.md).

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -32,7 +32,7 @@ This checklist is the current public-launch sign-off surface for Mimir. It cover
 | CI | Done on main | GitHub Actions main run was green on 2026-04-28 after PR #12. |
 | Docs index | Done | `docs/README.md`. |
 | Launch article | Done | `docs/blog/2026-04-28-agent-memory-compiler-pipeline.md`, linked from README and docs index. |
-| Publishing plan | Done | `docs/launch-posting-plan.md` covers GitHub, launch article, Show HN / X / LinkedIn, Codex plugin bundle, crates.io/docs.rs alpha, and the deferred MCP Registry path. |
+| GitHub release | Done | GitHub Release `v0.1.0` was published on 2026-04-28 with platform archives and checksum assets. |
 | Public artifact hygiene | Done | Scratch research fixtures removed from tracked files; recovery benchmark promoted to `benchmarks/recovery`; historical planning notes moved to `.planning/planning`; stale internal-path sweep returned no hits. |
 
 ## Engineering Quality Gate
@@ -82,16 +82,16 @@ Public-surface checks: confirm no tracked files remain under removed scratch dir
 | Transparent harness exists. | `mimir-harness` wraps native agent commands and records capture summaries. | Allowed, local/pre-1.0 wording only. |
 | Recovery mirroring exists. | `mimir remote status|push|pull|drill` exists. | Allowed as local Git-backed BC/DR, not hosted sync. |
 | Mimir improves recovery outcomes. | Benchmark harness exists; live transcript-backed results are not published yet. | Not allowed yet. |
-| Stable public API/storage format. | Pre-1.0 workspace version and no release tag. | Not allowed yet. |
+| Stable public API/storage format. | Pre-1.0 `v0.1.0` alpha release; command surfaces and storage may still change before v1.0. | Not allowed yet. |
 | Hosted service or daemonized librarian. | Service remote is adapter-boundary only. | Not allowed yet. |
 
 ## Version And Release State
 
 - Workspace version: `0.1.0`.
-- Release tags: none.
-- First public tag target: `v0.1.0`, after cleanup branch is locally green and owner approves tagging.
-- Crates.io publishing waits for the `mimir-core` publish dry-run, crate README audit, and release ordering through `mimir-core` first.
-- docs.rs will build after crates are published to crates.io.
+- Release tag: `v0.1.0` at commit `315d791`.
+- GitHub Release `v0.1.0` was published on 2026-04-28 with platform archives and checksum assets.
+- Release notes list `mimir-core`, `mimir-cli`, `mimir-mcp`, `mimir-librarian`, and `mimir-harness` as published crates.
+- docs.rs pages are downstream of crates.io publication and are not re-audited by this checklist.
 
 ## Deferred After Public Opening
 


### PR DESCRIPTION
## Summary
- replace stale public links to deleted launch-posting-plan docs with current release surfaces
- update STATUS and launch readiness for the published v0.1.0 release
- remove public GitHub template references to AGENTS.md while preserving product docs for Claude/Codex integration paths

## Verification
- git diff --check
- no top-level agent artifacts: find . -maxdepth 2 -name .agents -o -name .claude -o -name AGENTS.md -o -name CLAUDE.md -o -name WORKFLOW.md
- stale public-doc sweep: rg -n 'launch-posting-plan|release_tags: none|no release tag exists|pre-1.0 public launch cleanup|once it reaches its first release' README.md STATUS.md docs/README.md docs/launch-readiness.md RELEASING.md CHANGELOG.md
- gh release view v0.1.0 --json tagName,publishedAt,targetCommitish,url
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo test --workspace --all-features