### PR TITLE
chore(gitignore): align with BES OSS fleet posture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,9 @@ desktop.ini
 .helix/
 *.swp
 *.swo
+
+AGENT_INBOX.md
+
+AGENT_FEEDBACK.md
+
+SESSION_JOURNAL.md

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ AGENT_INBOX.md
 AGENT_FEEDBACK.md
 
 SESSION_JOURNAL.md
+
+.githooks/


### PR DESCRIPTION
## Summary
- Adds standard BES OSS gitignore entries:
  - `AGENT_INBOX.md`, `AGENT_FEEDBACK.md`, `SESSION_JOURNAL.md` — fleet workpads
  - `.githooks/` — fleet-baseline commit-msg + pre-push hooks managed by fleet-sync

## Why
Brings Mimir's gitignore in line with Wick's (PR buildepicshit/Wick#81 just merged). Per BES "Public OSS posture": agent-control content stays in working tree but is not tracked publicly.

## Test plan
- [x] `git status` clean after fleet-sync.sh oss run.